### PR TITLE
fix: 修复所有硬编码路径以适配 base 配置

### DIFF
--- a/src/component/novel-toc.astro
+++ b/src/component/novel-toc.astro
@@ -63,7 +63,7 @@ const { novel, currentChapter } = Astro.props;
           .map((chapter) => (
             <li class="chapter-item">
               <a 
-                href={`/novel/${novel.slug}/${chapter.slug}`}
+                href={`${import.meta.env.BASE_URL}/novel/${novel.slug}/${chapter.slug}`}
                 class={`chapter-link ${currentChapter === chapter.slug ? 'active' : ''}`}
                 data-chapter={chapter.slug}
               >
@@ -83,7 +83,7 @@ const { novel, currentChapter } = Astro.props;
 
     <!-- 返回小说列表 -->
     <div class="novel-actions">
-      <a href="/" class="back-to-list">
+      <a href={`${import.meta.env.BASE_URL}/`} class="back-to-list">
         ← 返回小说列表
       </a>
     </div>

--- a/src/component/tabs.astro
+++ b/src/component/tabs.astro
@@ -63,7 +63,7 @@ const tabData: Record<string, any[]> = {
               entries.map((entry: any) => (
                 <li class="content-item">
                   <a 
-                    href={entry.data.isNovel ? `/novel/${entry.slug}` : `/${entry.collection}/${entry.slug}`} 
+                    href={entry.data.isNovel ? `${import.meta.env.BASE_URL}/novel/${entry.slug}` : `${import.meta.env.BASE_URL}/${entry.collection}/${entry.slug}`} 
                     class="content-link"
                   >
                     <div class="content-header">
@@ -83,7 +83,7 @@ const tabData: Record<string, any[]> = {
                     {entry.data.tags && (
                       <div class="tags">
                         {entry.data.tags.map((tag: string) => (
-                          <a href={`/tags/${tag}`} class="tag">{tag}</a>
+                          <a href={`${import.meta.env.BASE_URL}/tags/${tag}`} class="tag">{tag}</a>
                         ))}
                       </div>
                     )}

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,1 +1,6 @@
 /// <reference path="../.astro/types.d.ts" />
+/// <reference types="astro/client" />
+
+interface ImportMetaEnv {
+  readonly BASE_URL: string;
+}

--- a/src/pages/[...path].astro
+++ b/src/pages/[...path].astro
@@ -28,7 +28,7 @@ const { Content, headings } = await entry.render();
 <html lang="zh-CN">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href={`/favicon.svg`} />
+    <link rel="icon" type="image/svg+xml" href={`${import.meta.env.BASE_URL}/favicon.svg`} />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{entry.data.title} - 太虚幻境</title>
     <meta name="description" content={entry.data.title} />
@@ -38,13 +38,13 @@ const { Content, headings } = await entry.render();
       <header class="article-header">
         <!-- <h1>{entry.data.title}</h1> -->
         <nav class="article-nav">
-          <a href="/" class="back-link">← 返回首页</a>
+          <a href={`${import.meta.env.BASE_URL}/`} class="back-link">← 返回首页</a>
           <div>
             {
               entry.data.tags && (
                 <div class="article-tags">
                   {entry.data.tags.map((tag: string) => (
-                    <a href={`/tags/${tag}`} class="tag">
+                    <a href={`${import.meta.env.BASE_URL}/tags/${tag}`} class="tag">
                       {tag}
                     </a>
                   ))}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -20,7 +20,7 @@ const {
 <html lang="zh-CN">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" type="image/svg+xml" href={`/favicon.svg`} />
+    <link rel="icon" type="image/svg+xml" href={`${import.meta.env.BASE_URL}/favicon.svg`} />
     <meta name="viewport" content="width=device-width" />
     <meta name="generator" content={metaContent} />
     <title>{title}</title>

--- a/src/pages/novel/[novelSlug]/[chapter].astro
+++ b/src/pages/novel/[novelSlug]/[chapter].astro
@@ -41,7 +41,7 @@ export async function getStaticPaths() {
 const { novel, currentChapter, allChapters } = Astro.props;
 
 // 找到当前章节的索引
-const currentIndex = allChapters.findIndex(ch => ch.slug === currentChapter.slug);
+const currentIndex = allChapters.findIndex((ch: { slug: any; }) => ch.slug === currentChapter.slug);
 const prevChapter = currentIndex > 0 ? allChapters[currentIndex - 1] : null;
 const nextChapter = currentIndex < allChapters.length - 1 ? allChapters[currentIndex + 1] : null;
 ---
@@ -50,7 +50,7 @@ const nextChapter = currentIndex < allChapters.length - 1 ? allChapters[currentI
 <html lang="zh-CN">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href={`/favicon.svg`} />
+    <link rel="icon" type="image/svg+xml" href={`${import.meta.env.BASE_URL}/favicon.svg`} />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{currentChapter.title} - {novel.data.title} - 太虚幻境</title>
     <meta name="description" content={`${novel.data.title} ${currentChapter.title}`} />
@@ -94,7 +94,7 @@ const nextChapter = currentIndex < allChapters.length - 1 ? allChapters[currentI
             <div class="nav-buttons">
               {prevChapter ? (
                 <a 
-                  href={`/novel/${novel.slug}/${prevChapter.slug}`}
+                  href={`${import.meta.env.BASE_URL}novel/${novel.slug}/${prevChapter.slug}`}
                   class="nav-btn prev-btn"
                 >
                   ← 上一章
@@ -104,7 +104,7 @@ const nextChapter = currentIndex < allChapters.length - 1 ? allChapters[currentI
               )}
               {nextChapter ? (
                 <a 
-                  href={`/novel/${novel.slug}/${nextChapter.slug}`}
+                  href={`${import.meta.env.BASE_URL}/novel/${novel.slug}/${nextChapter.slug}`}
                   class="nav-btn next-btn"
                 >
                   下一章 →

--- a/src/pages/novel/[novelSlug]/index.astro
+++ b/src/pages/novel/[novelSlug]/index.astro
@@ -29,7 +29,7 @@ const { Content } = await novel.render();
 <html lang="zh-CN">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href={`/favicon.svg`} />
+    <link rel="icon" type="image/svg+xml" href={`${import.meta.env.BASE_URL}/favicon.svg`} />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{novel.data.title} - 太虚幻境</title>
     <meta name="description" content={novel.data.description || novel.data.title} />
@@ -65,7 +65,7 @@ const { Content } = await novel.render();
             <div class="chapter-navigation">
               <h3>开始阅读</h3>
               <a 
-                href={`/novel/${novel.slug}/${novel.data.chapters[0].slug}`}
+                href={`${import.meta.env.BASE_URL}/novel/${novel.slug}/${novel.data.chapters[0].slug}`}
                 class="start-reading-btn"
               >
                 开始阅读第一章

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -44,7 +44,7 @@ const novelEntries = filteredEntries.filter((entry: { collection: string; }) => 
 <!DOCTYPE html>
 <html lang="zh-CN">
   <head>
-    <link rel="icon" type="image/svg+xml" href={`/favicon.svg`} />
+    <link rel="icon" type="image/svg+xml" href={`${import.meta.env.BASE_URL}/favicon.svg`} />
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width" />
     <title>标签: {tagString} - 太虚幻境</title>
@@ -74,7 +74,7 @@ const novelEntries = filteredEntries.filter((entry: { collection: string; }) => 
     </header>
     <main>
       <nav class="breadcrumb">
-        <a href="/" class="back-link">← 返回首页</a>
+        <a href={`${import.meta.env.BASE_URL}/`} class="back-link">← 返回首页</a>
         <!-- <div class="tag-search">
           <Search />
         </div> -->
@@ -87,7 +87,7 @@ const novelEntries = filteredEntries.filter((entry: { collection: string; }) => 
             <ul class="content-list">
               {techEntries.map((entry: any) => (
                 <li class="content-item">
-                  <a href={`/${entry.collection}/${entry.slug}`} class="content-link">
+                  <a href={`${import.meta.env.BASE_URL}/${entry.collection}/${entry.slug}`} class="content-link">
                     <h3>{entry.data.title}</h3>
                     {entry.data.tags && (
                       <div class="tags">
@@ -104,14 +104,14 @@ const novelEntries = filteredEntries.filter((entry: { collection: string; }) => 
             </ul>
           </section>
         )}
-        
+
         {novelEntries.length > 0 && (
           <section class="content-section">
             <h2 class="section-title">生活随笔</h2>
             <ul class="content-list">
               {novelEntries.map((entry: any) => (
                 <li class="content-item">
-                  <a href={`/${entry.collection}/${entry.slug}`} class="content-link">
+                  <a href={`${import.meta.env.BASE_URL}/${entry.collection}/${entry.slug}`} class="content-link">
                     <h3>{entry.data.title}</h3>
                     {entry.data.tags && (
                       <div class="tags">


### PR DESCRIPTION
- 将 /novel/、/tags/、/tech/、/ 等硬编码路径替换为 import.meta.env.BASE_URL 动态拼接
- 修复 favicon.svg 路径
- 在 env.d.ts 中补充 BASE_URL 类型声明
- 确保所有链接在 GitHub Pages 部署时正确包含 /nothingness 前缀